### PR TITLE
fix next head appearing in certain -f lookups

### DIFF
--- a/lib/Pod/Perldoc.pm
+++ b/lib/Pod/Perldoc.pm
@@ -1356,7 +1356,7 @@ sub search_perlfunc {
                 last if $found > 1 and $inlist < 2;
             }
         }
-        elsif (/^=item/) {
+        elsif (/^=item|^=back/) {
             last if $found > 1 and $inlist < 2;
         }
         elsif ($found and /^X<[^>]+>/) {


### PR DESCRIPTION
perlfunc.pod has groups of non-function keywords that direct users to the appropriate docs. Each of these are delimited by a `=head3`. If you look up one of the items in these lists, the next section's `=head3` shows up (for example, `AUTOLOAD`, `DESTROY`, `eq`).

This change stops gathering POD lines at the end of the list, instead of at the first item in the next list.
